### PR TITLE
Display different colors for response status code

### DIFF
--- a/Converters/HttpStatusCodeToColorConverter.cs
+++ b/Converters/HttpStatusCodeToColorConverter.cs
@@ -1,0 +1,36 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using System;
+using System.Globalization;
+using System.Net;
+
+namespace Lance.Converters
+{
+    public class HttpStatusCodeToColorConverter : IValueConverter
+    {
+        private static readonly SolidColorBrush SuccessColor = new(Colors.PaleGreen);
+        private static readonly SolidColorBrush ClientErrorColor = new(Colors.PaleGoldenrod);
+        private static readonly SolidColorBrush ServerErrorColor = new(Colors.PaleVioletRed);
+        private static readonly SolidColorBrush FallbackColor = new(Colors.Gray);
+
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is HttpStatusCode statusCode)
+            {
+                return statusCode switch
+                {
+                    < HttpStatusCode.BadRequest => SuccessColor,
+                    < HttpStatusCode.InternalServerError => ClientErrorColor,
+                    _ => ServerErrorColor
+                };
+            }
+
+            return FallbackColor;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -27,6 +28,8 @@ public partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty] private string? _formattedRequestTime;
 
     [ObservableProperty] private string? _formattedStatusCode;
+
+    [ObservableProperty] private HttpStatusCode? _statusCode;
 
     [ObservableProperty] private string? _responseContent;
 
@@ -115,6 +118,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         FormattedRequestTime = $"{Math.Round(requestDuration.TotalMilliseconds)} ms";
 
+        StatusCode = response.StatusCode;
         FormattedStatusCode = $"{(int)response.StatusCode} - {response.ReasonPhrase}";
 
         await SetResponseContent(response, stringResponseContent);

--- a/Views/MainWindow.axaml
+++ b/Views/MainWindow.axaml
@@ -12,6 +12,7 @@
 
     <Window.Resources>
         <localConverters:HttpMethodConverter x:Key="HttpMethodConverter" />
+		<localConverters:HttpStatusCodeToColorConverter x:Key="HttpStatusCodeToColorConverter"/>
     </Window.Resources>
 
     <Design.DataContext>
@@ -126,7 +127,7 @@
                 <TextBlock HorizontalAlignment="Left" Text="{Binding FormattedRequestTime}" />
                 <TextBlock
                     HorizontalAlignment="Right"
-                    Background="PaleGreen"
+                    Background="{Binding StatusCode, Converter={StaticResource HttpStatusCodeToColorConverter}}"
                     Foreground="Black"
                     Text="{Binding FormattedStatusCode}" />
             </Panel>


### PR DESCRIPTION
* Introduces a new property `StatusCode` to `MainWindowViewModel`
* Adds a new `HttpStatusCodeToColorConverter` which translates a HttpStatusCode to a SolidBrushColor
* Uses this new property and converter to bind to TextBlock's Background property used to display the response status